### PR TITLE
Add linking for message editing

### DIFF
--- a/YouTrackLinkerApp.ts
+++ b/YouTrackLinkerApp.ts
@@ -9,13 +9,13 @@ import {
     IRead,
 } from '@rocket.chat/apps-engine/definition/accessors';
 import { App } from '@rocket.chat/apps-engine/definition/App';
-import { IMessage, IPreMessageSentModify } from '@rocket.chat/apps-engine/definition/messages';
+import { IMessage, IPreMessageSentModify, IPreMessageUpdatedModify } from '@rocket.chat/apps-engine/definition/messages';
 import { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';
 import { ISetting } from '@rocket.chat/apps-engine/definition/settings';
 import { MessageHandler } from './src/handler/MessageHandler';
 import { Settings } from './src/settings/Settings';
 
-export class YouTrackLinkerApp extends App implements IPreMessageSentModify {
+export class YouTrackLinkerApp extends App implements IPreMessageSentModify, IPreMessageUpdatedModify {
 
     private readonly settings: Settings = new Settings();
     private readonly messageHandler: MessageHandler;
@@ -26,12 +26,21 @@ export class YouTrackLinkerApp extends App implements IPreMessageSentModify {
     }
 
     public async checkPreMessageSentModify(message: IMessage, read: IRead, http: IHttp): Promise<boolean> {
-        return this.messageHandler.checkPreMessageSentModify(message, read, http);
+        return this.messageHandler.checkPreMessageModify(message, read, http);
+    }
+
+    public async checkPreMessageUpdatedModify(message: IMessage, read: IRead, http: IHttp): Promise<boolean> {
+        return this.messageHandler.checkPreMessageModify(message, read, http);
     }
 
     // tslint:disable-next-line:max-line-length
     public async executePreMessageSentModify(message: IMessage, builder: IMessageBuilder, read: IRead, http: IHttp, persistence: IPersistence): Promise<IMessage> {
-        return this.messageHandler.executePreMessageSentModify(message, builder, read, http, persistence);
+        return this.messageHandler.executePreMessageModify(message, builder, read, http, persistence);
+    }
+
+    // tslint:disable-next-line:max-line-length
+    public async executePreMessageUpdatedModify(message: IMessage, builder: IMessageBuilder, read: IRead, http: IHttp, persistence: IPersistence): Promise<IMessage> {
+        return this.messageHandler.executePreMessageModify(message, builder, read, http, persistence);
     }
 
     public async onEnable(environmentRead: IEnvironmentRead, configModify: IConfigurationModify): Promise<boolean> {

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "id": "9408b583-2f0e-4987-a341-daa171d761ce",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "requiredApiVersion": "^1.12.0",
     "iconFile": "icon.png",
     "author": {
@@ -13,6 +13,7 @@
     "classFile": "YouTrackLinkerApp.ts",
     "description": "Turns YouTrack references into links.",
     "implements": [
-        "IPreMessageSentModify"
+        "IPreMessageSentModify",
+        "IPreMessageUpdatedModify"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "test": "mocha -r ts-node/register **/*.test.ts",
         "coverage": "nyc npm run test",
         "coveralls": "npm run coverage && nyc report --reporter=text-lcov | coveralls",
-        "package": "rc-apps package"
+        "package": "rc-apps package",
+        "submit": "rc-apps submit"
     },
     "pre-commit": [
         "lint",

--- a/src/handler/MessageHandler.test.ts
+++ b/src/handler/MessageHandler.test.ts
@@ -66,7 +66,7 @@ describe('MessageHandler', () => {
                 const messageHandler = new MessageHandler(settings);
 
                 // tslint:disable-next-line: no-unused-expression
-                expect(await messageHandler.checkPreMessageSentModify(message, read, http)).to.be.true;
+                expect(await messageHandler.checkPreMessageModify(message, read, http)).to.be.true;
             });
             it('issue in attachment', async () => {
                 message.text = 'There is no any issue in message text';
@@ -74,7 +74,7 @@ describe('MessageHandler', () => {
                 const messageHandler = new MessageHandler(settings);
 
                 // tslint:disable-next-line: no-unused-expression
-                expect(await messageHandler.checkPreMessageSentModify(message, read, http)).to.be.true;
+                expect(await messageHandler.checkPreMessageModify(message, read, http)).to.be.true;
             });
             it('undefinded message text and issue in attachment', async () => {
                 message.text = undefined;
@@ -82,7 +82,7 @@ describe('MessageHandler', () => {
                 const messageHandler = new MessageHandler(settings);
 
                 // tslint:disable-next-line: no-unused-expression
-                expect(await messageHandler.checkPreMessageSentModify(message, read, http)).to.be.true;
+                expect(await messageHandler.checkPreMessageModify(message, read, http)).to.be.true;
             });
             it('empty message text and issue in attachment', async () => {
                 message.text = '';
@@ -90,7 +90,7 @@ describe('MessageHandler', () => {
                 const messageHandler = new MessageHandler(settings);
 
                 // tslint:disable-next-line: no-unused-expression
-                expect(await messageHandler.checkPreMessageSentModify(message, read, http)).to.be.true;
+                expect(await messageHandler.checkPreMessageModify(message, read, http)).to.be.true;
             });
             it('issue in message text and attachment', async () => {
                 message.text = 'There is an issue in message text: TEST-10';
@@ -98,7 +98,7 @@ describe('MessageHandler', () => {
                 const messageHandler = new MessageHandler(settings);
 
                 // tslint:disable-next-line: no-unused-expression
-                expect(await messageHandler.checkPreMessageSentModify(message, read, http)).to.be.true;
+                expect(await messageHandler.checkPreMessageModify(message, read, http)).to.be.true;
             });
         });
 
@@ -107,21 +107,21 @@ describe('MessageHandler', () => {
                 message.text = 'There is no any issue in message text';
                 const messageHandler = new MessageHandler(settings);
                 // tslint:disable-next-line: no-unused-expression
-                expect(await messageHandler.checkPreMessageSentModify(message, read, http)).to.be.false;
+                expect(await messageHandler.checkPreMessageModify(message, read, http)).to.be.false;
             });
             it('undefinded message text and no any attachment', async () => {
                 message.text = undefined;
                 const messageHandler = new MessageHandler(settings);
 
                 // tslint:disable-next-line: no-unused-expression
-                expect(await messageHandler.checkPreMessageSentModify(message, read, http)).to.be.false;
+                expect(await messageHandler.checkPreMessageModify(message, read, http)).to.be.false;
             });
             it('empty message text and no any attachment', async () => {
                 message.text = '';
                 const messageHandler = new MessageHandler(settings);
 
                 // tslint:disable-next-line: no-unused-expression
-                expect(await messageHandler.checkPreMessageSentModify(message, read, http)).to.be.false;
+                expect(await messageHandler.checkPreMessageModify(message, read, http)).to.be.false;
             });
             it('undefinded message text and no any issue in attachment', async () => {
                 message.text = undefined;
@@ -129,14 +129,14 @@ describe('MessageHandler', () => {
                 const messageHandler = new MessageHandler(settings);
 
                 // tslint:disable-next-line: no-unused-expression
-                expect(await messageHandler.checkPreMessageSentModify(message, read, http)).to.be.false;
+                expect(await messageHandler.checkPreMessageModify(message, read, http)).to.be.false;
             });
             it('empty message text and no any attachment', async () => {
                 message.text = '';
                 const messageHandler = new MessageHandler(settings);
 
                 // tslint:disable-next-line: no-unused-expression
-                expect(await messageHandler.checkPreMessageSentModify(message, read, http)).to.be.false;
+                expect(await messageHandler.checkPreMessageModify(message, read, http)).to.be.false;
             });
             it('no any issue in message text and attachment', async () => {
                 message.text = 'There is no any issue in message text';
@@ -144,7 +144,7 @@ describe('MessageHandler', () => {
                 const messageHandler = new MessageHandler(settings);
 
                 // tslint:disable-next-line: no-unused-expression
-                expect(await messageHandler.checkPreMessageSentModify(message, read, http)).to.be.false;
+                expect(await messageHandler.checkPreMessageModify(message, read, http)).to.be.false;
             });
         });
     });
@@ -154,21 +154,21 @@ describe('MessageHandler', () => {
             message.text = 'There is an issue in message text: TEST-10';
             const messageHandler = new MessageHandler(settings);
 
-            expect((await messageHandler.executePreMessageSentModify(message, messageBuilder, read, http, persistence)).text)
+            expect((await messageHandler.executePreMessageModify(message, messageBuilder, read, http, persistence)).text)
                 .to.not.equal(message.text);
         });
         it('should return the same message text', async () => {
             message.text = 'There is no any issue in message text';
             const messageHandler = new MessageHandler(settings);
 
-            expect((await messageHandler.executePreMessageSentModify(message, messageBuilder, read, http, persistence)).text)
+            expect((await messageHandler.executePreMessageModify(message, messageBuilder, read, http, persistence)).text)
                 .to.equal(message.text);
         });
         it('should return the same message text', async () => {
             message.text = undefined;
             const messageHandler = new MessageHandler(settings);
 
-            expect((await messageHandler.executePreMessageSentModify(message, messageBuilder, read, http, persistence)).text)
+            expect((await messageHandler.executePreMessageModify(message, messageBuilder, read, http, persistence)).text)
                 .to.equal(message.text);
         });
 
@@ -177,7 +177,7 @@ describe('MessageHandler', () => {
             message.attachments = [{ text: 'There is an issue in attachment: TEST-10' }];
             const messageHandler = new MessageHandler(settings);
 
-            expect((await messageHandler.executePreMessageSentModify(message, messageBuilder, read, http, persistence)).attachments)
+            expect((await messageHandler.executePreMessageModify(message, messageBuilder, read, http, persistence)).attachments)
                 .to.not.eql(message.attachments);
         });
         it('should return the same attachment', async () => {
@@ -185,7 +185,7 @@ describe('MessageHandler', () => {
             message.attachments = [{ text: 'There is no any issue in attachment' }];
             const messageHandler = new MessageHandler(settings);
 
-            expect((await messageHandler.executePreMessageSentModify(message, messageBuilder, read, http, persistence)).attachments)
+            expect((await messageHandler.executePreMessageModify(message, messageBuilder, read, http, persistence)).attachments)
                 .to.eql(message.attachments);
         });
         it('should return the same attachment', async () => {
@@ -193,7 +193,7 @@ describe('MessageHandler', () => {
             message.attachments = [{ text: undefined }];
             const messageHandler = new MessageHandler(settings);
 
-            expect((await messageHandler.executePreMessageSentModify(message, messageBuilder, read, http, persistence)).attachments)
+            expect((await messageHandler.executePreMessageModify(message, messageBuilder, read, http, persistence)).attachments)
                 .to.eql(message.attachments);
         });
         it('should return the same attachment', async () => {
@@ -201,7 +201,7 @@ describe('MessageHandler', () => {
             message.attachments = [{ text: '' }];
             const messageHandler = new MessageHandler(settings);
 
-            expect((await messageHandler.executePreMessageSentModify(message, messageBuilder, read, http, persistence)).attachments)
+            expect((await messageHandler.executePreMessageModify(message, messageBuilder, read, http, persistence)).attachments)
                 .to.eql(message.attachments);
         });
 
@@ -210,9 +210,9 @@ describe('MessageHandler', () => {
             message.attachments = [{ text: 'There is an issue in attachment: TEST-10' }];
             const messageHandler = new MessageHandler(settings);
 
-            expect((await messageHandler.executePreMessageSentModify(message, messageBuilder, read, http, persistence)).text)
+            expect((await messageHandler.executePreMessageModify(message, messageBuilder, read, http, persistence)).text)
                 .to.not.equal(message.text);
-            expect((await messageHandler.executePreMessageSentModify(message, messageBuilder, read, http, persistence)).attachments)
+            expect((await messageHandler.executePreMessageModify(message, messageBuilder, read, http, persistence)).attachments)
                 .to.not.eql(message.attachments);
         });
         it('should return the same message text and attachment', async () => {
@@ -220,9 +220,9 @@ describe('MessageHandler', () => {
             message.attachments = [{ text: 'There is no any issue in attachment' }];
             const messageHandler = new MessageHandler(settings);
 
-            expect((await messageHandler.executePreMessageSentModify(message, messageBuilder, read, http, persistence)).text)
+            expect((await messageHandler.executePreMessageModify(message, messageBuilder, read, http, persistence)).text)
                 .to.equal(message.text);
-            expect((await messageHandler.executePreMessageSentModify(message, messageBuilder, read, http, persistence)).attachments)
+            expect((await messageHandler.executePreMessageModify(message, messageBuilder, read, http, persistence)).attachments)
                 .to.eql(message.attachments);
         });
     });

--- a/src/handler/MessageHandler.ts
+++ b/src/handler/MessageHandler.ts
@@ -1,9 +1,9 @@
 import { IHttp, IMessageBuilder, IPersistence, IRead } from '@rocket.chat/apps-engine/definition/accessors';
-import { IMessage, IMessageAttachment, IPreMessageSentModify } from '@rocket.chat/apps-engine/definition/messages';
+import { IMessage, IMessageAttachment } from '@rocket.chat/apps-engine/definition/messages';
 import { Settings } from '../settings/Settings';
 import { TextMessage } from './TextMessage';
 
-export class MessageHandler implements IPreMessageSentModify {
+export class MessageHandler {
 
     private readonly settings: Settings;
 
@@ -11,7 +11,7 @@ export class MessageHandler implements IPreMessageSentModify {
         this.settings = settings;
     }
 
-    public async checkPreMessageSentModify(message: IMessage, read: IRead, http: IHttp): Promise<boolean> {
+    public async checkPreMessageModify(message: IMessage, read: IRead, http: IHttp): Promise<boolean> {
         if (message.text && await this.hasIssues(message.text)) {
             return true;
         }
@@ -28,7 +28,7 @@ export class MessageHandler implements IPreMessageSentModify {
     }
 
     // tslint:disable-next-line:max-line-length
-    public async executePreMessageSentModify(message: IMessage, builder: IMessageBuilder, read: IRead, http: IHttp, persistence: IPersistence): Promise<IMessage> {
+    public async executePreMessageModify(message: IMessage, builder: IMessageBuilder, read: IRead, http: IHttp, persistence: IPersistence): Promise<IMessage> {
         if (message.text) {
             await this.modifyText(message.text).then((messageText) => builder.setText(messageText));
         }


### PR DESCRIPTION
While editing it wasn't possible to add a new issue
reference to be processed by linker. Now linker
processes message text after editing.

Closes #11